### PR TITLE
Change build.zig.zon to build with 0.14 stable

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "godot",
+    .name = .godot,
+    .fingerprint = 0x74a61aa48e9841ab,
     .version = "0.0.0-dev",
     .dependencies = .{
         .case = .{


### PR DESCRIPTION
Zig 0.14 requires the build.zig.zon file to be updated. A fingerprint is generated by `zig build` to be inserted in this file as well.

I don't know yet if this is the only change that will be needed for zig 0.14.